### PR TITLE
fix: change go.mod to require Go 1.21 instead of unreleased Go 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/souravsspace/unsent-go
 
-go 1.25.5
+go 1.21
 
 require github.com/oapi-codegen/runtime v1.1.2
 


### PR DESCRIPTION
## Summary
- Changes `go.mod` to require Go 1.21 instead of Go 1.25.5

## Problem
The current `go.mod` requires Go 1.25.5 which doesn't exist yet (latest stable is Go 1.23.x). This prevents anyone from installing or using the SDK:

```
go: github.com/souravsspace/unsent-go@v1.0.4 requires go >= 1.25.5 (running go 1.23.12; GOTOOLCHAIN=local)
```

## Solution
Changed to Go 1.21 which is widely supported and maintains full compatibility with the SDK's code.

## Test plan
- [x] Verified SDK compiles with Go 1.23
- [x] Verified all API calls work correctly after patching

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)